### PR TITLE
Fix /artmap list displaying incorrect total pages

### DIFF
--- a/src/main/java/me/Fupery/ArtMap/Command/CommandList.java
+++ b/src/main/java/me/Fupery/ArtMap/Command/CommandList.java
@@ -53,8 +53,8 @@ public class CommandList extends ArtMapCommand {
             return false;
         }
 
-        //index of the last page
-        int totalPages = (list.length / 8) + 1;
+        //maximum number of pages
+        int totalPages = (list.length - 1) / 8 + 1;
 
         if (pg > totalPages) {
             pg = totalPages;


### PR DESCRIPTION
Fix the list command displaying the incorrect number of pages when the map count is divisible by 8. For 0 it will say 0 pages, which is technically incorrect, but that's handled prior anyway.